### PR TITLE
Fix outdated reference in beacon README

### DIFF
--- a/sw/beacon/README.md
+++ b/sw/beacon/README.md
@@ -15,7 +15,6 @@ beacon/
 │   ├── QRSS.h              ## QRSS base class and specialized FSK-CW and CW subclasses
 |   |── QRSS.cpp
 |   |── WSPR.h              ## WSPR transmission
-|   |── UWSPR.cpp
 |   |── TimeSync.h          ## Class to handle RTC to GPS time synchronization and alarms
 |   |── TimeSync.cpp
 |   └── 


### PR DESCRIPTION
## Summary
- remove obsolete `UWSPR.cpp` entry from the file overview

## Testing
- `grep -n UWSPR sw/beacon/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6849d350e6748333a6ff048735eb64e3